### PR TITLE
Combine Functions

### DIFF
--- a/AutoExpandFormulas.gs
+++ b/AutoExpandFormulas.gs
@@ -70,7 +70,14 @@ function updateTransformTab(columnLetter) {
 transformSheet.getRange('A2:Z' + lastRow).clearContent();
 
 var combinedData = getCombinedColumn(columnLetter); // Get combined data from FY tabs
+
+//Clear content in specified column before updating
+transformSheet.getRange(columnLetter + '2:' + columnLetter + lastRow.clearContent();
+
   for (var i = 0; i < combinedData.length; i++) {
     transformSheet.getRange(columnLetter + (i + 2)).setValue(combinedData[i]); // Update TRANSFORM tab
   }
+
+// Log the final update status
+Logger.log("Updated TRANSFORM tab with new data.");
 }

--- a/AutoExpandFormulas.gs
+++ b/AutoExpandFormulas.gs
@@ -5,14 +5,15 @@
  * @param {string} columnLetter - The letter of the column to combine.
  * @returns {Array} - An array containing combined data from the specified column.
  */
+
 function getCombinedColumn(columnLetter) {
+  // Use a default column letter if none is provided
+  columnLetter = columnLetter || 'A';
+  Logger.log("Column letter: " + columnLetter);
+
   var ss = SpreadsheetApp.getActiveSpreadsheet(); // Get the active spreadsheet
   var sheets = ss.getSheets(); // Get all sheets in the spreadsheet
   var combinedData = []; // Initialize an array to store combined data
-
-  // Ensure columnLetter is always defined
-  columnLetter = columnLetter || 'A';
-  Logger.log("Column letter: " + columnLetter);
 
   // Iterate through each sheet in the spreadsheet
   for (var i = 0; i < sheets.length; i++) {
@@ -27,7 +28,7 @@ function getCombinedColumn(columnLetter) {
       // Ensure there's data beyond the header row
       if (lastRow > 1) {
         try {
-          // Log the range string
+          // Construct the range string
           var rangeStr = columnLetter + '2:' + columnLetter + lastRow;
           Logger.log("Range string: " + rangeStr);
           
@@ -59,25 +60,24 @@ function getCombinedColumn(columnLetter) {
 }
 
 /**
- * Clears the content of the TRANSFORM tab from row 2 downwards before updating.
+ * Clears the content of the TRANSFORM tab from row 2 downwards before updating it.
  *
  * @param {string} columnLetter - The letter of the column to combine.
  */
 function updateTransformTab(columnLetter) {
+  // Use a default column letter if none is provided
+  columnLetter = columnLetter || 'A';
+  Logger.log("Updating TRANSFORM tab with column letter: " + columnLetter);
+
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   var transformSheet = ss.getSheetByName('TRANSFORM'); // Get the TRANSFORM tab
   var lastRow = transformSheet.getLastRow();
-  
-  // Clear existing content from row 2 onwards, from column A to Z
-  transformSheet.getRange('A2:Z' + lastRow).clearContent();
+  transformSheet.getRange('A2:Z' + lastRow).clearContent(); // Clear existing content from row 2 onwards
 
   var combinedData = getCombinedColumn(columnLetter); // Get combined data from FY tabs
-
-  // Update TRANSFORM tab with combined data
   for (var i = 0; i < combinedData.length; i++) {
-    transformSheet.getRange(columnLetter + (i + 2)).setValue(combinedData[i]);
+    transformSheet.getRange(columnLetter + (i + 2)).setValue(combinedData[i]); // Update TRANSFORM tab
   }
-  
-  // Log the final update status
+
   Logger.log("Updated TRANSFORM tab with new data.");
 }

--- a/AutoExpandFormulas.gs
+++ b/AutoExpandFormulas.gs
@@ -10,20 +10,24 @@ function getCombinedColumn(columnLetter) {
   var sheets = ss.getSheets(); // Get all sheets in the spreadsheet
   var combinedData = []; // Initialize an array to store combined data
 
-  // Iterate through each sheet in the spreadsheet
-  for (var i = 0; i < sheets.length; i++) {
+// Ensure columnLetter is always defined
+columnLetter = columnLetter || 'A';
+Logger.log("Column Letter: " + columnLetter);
+
+// Iterate through each sheet in the spreadsheet
+for (var i = 0; i < sheets.length; i++) {
     var sheet = sheets[i];
     var sheetName = sheet.getName();
     
-    // Check if the sheet name starts with 'FY'
-    if (sheetName.startsWith('FY')) {
+// Check if the sheet name starts with 'FY'
+if (sheetName.startsWith('FY')) {
       var lastRow = sheet.getLastRow(); // Get the last row with data in the sheet
       Logger.log("Processing sheet: " + sheetName + ", lastRow: " + lastRow);
       
-      // Ensure there's data beyond the header row
-      if (lastRow > 1) {
+  // Ensure there's data beyond the header row
+  if (lastRow > 1) {
         try {
-          // Construct the range string
+          // Log the range string
           var rangeStr = columnLetter + '2:' + columnLetter + lastRow;
           Logger.log("Range string: " + rangeStr);
           
@@ -50,4 +54,23 @@ function getCombinedColumn(columnLetter) {
   // Log the combined data for debugging purposes
   Logger.log("Combined Data: " + combinedData.join(", "));
   return combinedData; // Return the combined data
+}
+
+/**
+ * Clears the content of the TRANSFORM tab from row 2 down before updating.
+ *
+ * @param {string} columnLetter - The letter of the column to combine.
+ */
+function updateTransformTab(columnLetter) {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var transformSheet = ss.getSheetByName('TRANSFORM'); // Get the TRANSFORM tab
+  var lastRow = transformSheet.getLastRow();
+
+// Clear existing content from row 2 and below, columns A to Z
+transformSheet.getRange('A2:Z' + lastRow).clearContent();
+
+var combinedData = getCombinedColumn(columnLetter); // Get combined data from FY tabs
+  for (var i = 0; i < combinedData.length; i++) {
+    transformSheet.getRange(columnLetter + (i + 2)).setValue(combinedData[i]); // Update TRANSFORM tab
+  }
 }

--- a/AutoExpandFormulas.gs
+++ b/AutoExpandFormulas.gs
@@ -1,6 +1,6 @@
 /**
  * Combines data from a specified column across all sheets
- * whose names start with 'FY'. 
+ * whose names start with 'FY'.
  *
  * @param {string} columnLetter - The letter of the column to combine.
  * @returns {Array} - An array containing combined data from the specified column.
@@ -10,22 +10,22 @@ function getCombinedColumn(columnLetter) {
   var sheets = ss.getSheets(); // Get all sheets in the spreadsheet
   var combinedData = []; // Initialize an array to store combined data
 
-// Ensure columnLetter is always defined
-columnLetter = columnLetter || 'A';
-Logger.log("Column Letter: " + columnLetter);
+  // Ensure columnLetter is always defined
+  columnLetter = columnLetter || 'A';
+  Logger.log("Column letter: " + columnLetter);
 
-// Iterate through each sheet in the spreadsheet
-for (var i = 0; i < sheets.length; i++) {
+  // Iterate through each sheet in the spreadsheet
+  for (var i = 0; i < sheets.length; i++) {
     var sheet = sheets[i];
     var sheetName = sheet.getName();
     
-// Check if the sheet name starts with 'FY'
-if (sheetName.startsWith('FY')) {
+    // Check if the sheet name starts with 'FY'
+    if (sheetName.startsWith('FY')) {
       var lastRow = sheet.getLastRow(); // Get the last row with data in the sheet
       Logger.log("Processing sheet: " + sheetName + ", lastRow: " + lastRow);
       
-  // Ensure there's data beyond the header row
-  if (lastRow > 1) {
+      // Ensure there's data beyond the header row
+      if (lastRow > 1) {
         try {
           // Log the range string
           var rangeStr = columnLetter + '2:' + columnLetter + lastRow;
@@ -48,6 +48,8 @@ if (sheetName.startsWith('FY')) {
         // Log a message if the sheet has no data beyond the header row
         Logger.log("Sheet " + sheetName + " has no data beyond the header row.");
       }
+    } else {
+      Logger.log("Skipping sheet: " + sheetName + " (does not start with 'FY')");
     }
   }
   
@@ -57,7 +59,7 @@ if (sheetName.startsWith('FY')) {
 }
 
 /**
- * Clears the content of the TRANSFORM tab from row 2 down before updating.
+ * Clears the content of the TRANSFORM tab from row 2 downwards before updating.
  *
  * @param {string} columnLetter - The letter of the column to combine.
  */
@@ -65,19 +67,17 @@ function updateTransformTab(columnLetter) {
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   var transformSheet = ss.getSheetByName('TRANSFORM'); // Get the TRANSFORM tab
   var lastRow = transformSheet.getLastRow();
+  
+  // Clear existing content from row 2 onwards, from column A to Z
+  transformSheet.getRange('A2:Z' + lastRow).clearContent();
 
-// Clear existing content from row 2 and below, columns A to Z
-transformSheet.getRange('A2:Z' + lastRow).clearContent();
+  var combinedData = getCombinedColumn(columnLetter); // Get combined data from FY tabs
 
-var combinedData = getCombinedColumn(columnLetter); // Get combined data from FY tabs
-
-//Clear content in specified column before updating
-transformSheet.getRange(columnLetter + '2:' + columnLetter + lastRow.clearContent();
-
+  // Update TRANSFORM tab with combined data
   for (var i = 0; i < combinedData.length; i++) {
-    transformSheet.getRange(columnLetter + (i + 2)).setValue(combinedData[i]); // Update TRANSFORM tab
+    transformSheet.getRange(columnLetter + (i + 2)).setValue(combinedData[i]);
   }
-
-// Log the final update status
-Logger.log("Updated TRANSFORM tab with new data.");
+  
+  // Log the final update status
+  Logger.log("Updated TRANSFORM tab with new data.");
 }


### PR DESCRIPTION
The original GAS for getCombinedColumn has been optimized to catch the removal or addition of tabs, and to successful sort the addition of data by FY descending.

An additional updateTransformTab function was added which specifically clears the TRANSFORM tab below Row 2 so that the getCombinedColumn formulas can generate fresh data. Ideally, the functions are run gCC->uTT->gCC.

Further optimization can be achieved by reducing all actions to one function OR eliminating a potential error that caused gCC to need to be run twice. Not high priority as these are triggered & the use case is limited.